### PR TITLE
Fix closing markdown block

### DIFF
--- a/lab/terraform/README.md
+++ b/lab/terraform/README.md
@@ -69,7 +69,7 @@ You’ll supply inputs via `.tfvars`, inspect outputs for verification (SSH, DNS
     ├── CSV/
     ├── JSON/
     └── Logs/
-````
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- correct code block delimiter in Terraform lab README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882e0c163d483279ce533d9296277e7